### PR TITLE
POD patch to clarify which order to apply pragmas (and mention Moose)

### DIFF
--- a/lib/experimental.pm
+++ b/lib/experimental.pm
@@ -139,6 +139,26 @@ The supported features, documented further below, are:
 	smartmatch    - allow the use of ~~
 	switch        - allow the use of ~~, given, and when
 
+=head2 Ordering matters
+
+Using this pragma to 'enable an experimental feature' is another way of saying
+that this pragma will disable the warnings which would result from using that
+feature.  Therefore, the order in which pragmas are applied is important.  In
+particular, you probably want to enable experimental features I<after> you
+enable warnings:
+
+  use warnings;
+  use experimental 'smartmatch';
+
+You also need to take care with modules that enable warnings for you.  A common
+example being Moose.  In this example, warnings for the 'smartmatch' feature are
+first turned on by the warnings pragma, off by the experimental pragma and back
+on again by the Moose module (fix is to switch the last two lines):
+
+  use warnings;
+  use experimental 'smartmatch';
+  use Moose;
+
 =head2 Disclaimer
 
 Because of the nature of the features it enables, forward compatibility can not


### PR DESCRIPTION
Hi Leon

Thanks for your useful module. I ran into an issue in some existing code that used smartmatching and Moose. Adding `use experimental 'smartmatch'` appeared not to work because the `use Moose` was turning all warnings back on.  So not a bug in your code but a POD patch to help others who might hit the same issue.

Regards
Grant
