### PR TITLE
Remove autoderef:

### DIFF
--- a/lib/experimental.pm
+++ b/lib/experimental.pm
@@ -39,6 +39,7 @@ my %min_version = (
 	unicode_strings => '5.12.0',
 );
 my %max_version = (
+	autoderef       => '5.23.1',
 	lexical_topic   => '5.23.4',
 );
 


### PR DESCRIPTION
The autoderef feature was removed in 5.23.1. This change notes where it
was removed and also removes the documentation of it.

This addresses [RT #122274](https://rt.cpan.org/Public/Bug/Display.html?id=122274).