### PR TITLE
add a passing test to allow installation on <5.10

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -5,6 +5,8 @@ use warnings;
 
 use Test::More 0.89;
 
+plan skip_all => 'This module is a no-op on perls earlier than 5.010' if "$]" < 5.010000;
+
 local $SIG{__WARN__} = sub { fail("Got unexpected warning"); diag($_[0]) };
 
 if ($] >= 5.010000) {


### PR DESCRIPTION
otherwise, installation fails because the test generates no output.