### PR TITLE
Don't test for experimental::smartmatch if it's a no-op

### DIFF
--- a/lib/experimental.pm
+++ b/lib/experimental.pm
@@ -241,9 +241,13 @@ This was added in perl 5.20.0.
 This was added in perl 5.10.0, but it should be noted there are significant
 incompatibilities between 5.10.0 and 5.10.1.
 
+The feature is going to be deprecated in perl 5.38.0, and removed in 5.42.0.
+
 =item * C<switch> - allow the use of C<~~>, given, and when
 
 This was added in perl 5.10.0.
+
+The feature is going to be deprecated in perl 5.38.0, and removed in 5.42.0.
 
 =item * C<try> - allow the use of C<try> and C<catch>
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -18,7 +18,9 @@ if ($] >= 5.010000) {
 END
 }
 
-if ($] >= 5.010001) {
+use warnings ();
+if ( $] >= 5.010001
+    && ( $] < 5.017011 || exists $warnings::Offsets{"experimental::smartmatch"} ) ) {
 	is (eval <<'END', 1, 'switch compiles') or diag $@;
 	use experimental 'switch';
 	sub bar { 1 };
@@ -34,7 +36,8 @@ if ($] >= 5.010001) {
 END
 }
 
-if ($] >= 5.010001) {
+if ( $] >= 5.010001
+    && ( $] < 5.017011 || exists $warnings::Offsets{"experimental::smartmatch"} ) ) {
 	is (eval <<'END', 1, 'smartmatch compiles') or diag $@;
 	use experimental 'smartmatch';
 	sub baz { 1 };


### PR DESCRIPTION
The smartmatch operator (as well as `given` and `when`) is being deprecated in Perl 5.38.

Only run the tests for `experimental::smartmatch` if the warning exists.