### PR TITLE
fix the name of extra_paired_delimiters feature

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for experimental
 {{$NEXT}}
           - Fix the name of the extra_paired_delimiters feature (previously
             mis-documented as extra_paired_delims)
+          - Added "stable.pm", which acts like experimental.pm only for
+            features which have been marked non-experimental in their current
+            form, in later version of perl.
 
 0.030     2022-12-10 13:02:15+01:00 Europe/Amsterdam
           - Adapt to future deprecation of smartmatch

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for experimental
 
 {{$NEXT}}
+          - Fix the name of the extra_paired_delimiters feature (previously
+            mis-documented as extra_paired_delims)
 
 0.030     2022-12-10 13:02:15+01:00 Europe/Amsterdam
           - Adapt to future deprecation of smartmatch

--- a/lib/experimental.pm
+++ b/lib/experimental.pm
@@ -29,7 +29,7 @@ my %min_version = (
 	declared_refs   => '5.26.0',
 	defer           => '5.35.4',
 	evalbytes       => '5.16.0',
-	extra_paired_delims => '5.35.9',
+	extra_paired_delimiters => '5.35.9',
 	fc              => '5.16.0',
 	for_list        => '5.35.5',
 	isa             => '5.31.7',
@@ -191,7 +191,7 @@ This was added in perl 5.26.0.
 
 This was added in perl 5.36.0
 
-=item * C<extra_paired_delims> - enables the use of more paired string delimiters than the
+=item * C<extra_paired_delimiters> - enables the use of more paired string delimiters than the
 traditional four, S<C<< <  > >>>, S<C<( )>>, S<C<{ }>>, and S<C<[ ]>>.
 
 This was added in perl 5.36.


### PR DESCRIPTION
Using the right name, like…

```perl
use experimental 'extra_paired_delimiters';
```

…worked, but the docs said extra_paired_delims and so did the min. version check.