### PR TITLE
[pod] stable.pm: Refer as experiments

### DIFF
--- a/lib/stable.pm
+++ b/lib/stable.pm
@@ -48,7 +48,7 @@ sub unimport {
 
 =head1 DESCRIPTION
 
-The L<experimental> pragma makes it easy to turn on experimental while turning
+The L<experimental> pragma makes it easy to turn on experiments while turning
 off associated warnings.  You should read about it, if you don't already know
 what it does.
 


### PR DESCRIPTION
experimental -> experiments

Turn the adjective to plural noun, avoiding repeating the word