### PR TITLE
feature extra_paired_delimiters not considered stable

### DIFF
--- a/lib/stable.pm
+++ b/lib/stable.pm
@@ -12,7 +12,6 @@ my %allow_at = (
 	isa           => 5.032000,
 	lexical_subs  => 5.022000,
 	postderef     => 5.020000,
-	extra_paired_delimiters => 5.036000,
 	const_attr    => 5.022000,
 	for_list      => 5.036000,
 );
@@ -127,8 +126,6 @@ Lexical subroutines were actually added in 5.18, and their design did not
 change, but significant bugs makes them unsafe to use before 5.22.
 
 =item * C<postderef> - stable as of perl 5.20, available via stable 0.031
-
-=item * C<extra_paired_delimiters> - stable as of perl 5.36, available via stable 0.032
 
 =item * C<const_attr> - stable as of perl 5.22, available via stable 0.032
 


### PR DESCRIPTION
# Changes
- Push the change from core https://github.com/Perl/perl5/pull/22229/commits/5a4c2ce8a86f85fd87c0ab91b856f24c4e9a5cd9